### PR TITLE
Add Robinhood options history exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
 # robin_options_analysis
+
+This repository contains a small utility script for exporting your option order history from Robinhood.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install robin-stocks Flask
+   ```
+
+## Fetch option orders
+
+Run the script to authenticate and export your option orders to a JSON file.
+If you use two-factor authentication, you will be prompted for the code after
+entering your password:
+
+```bash
+python fetch_options_history.py
+```
+
+The script outputs `option_orders.json` containing all option orders associated with the account.
+
+## Web application
+
+Start the Flask web server and visit `http://localhost:5000` in your browser:
+
+```bash
+python webapp.py
+```
+
+Enter your Robinhood credentials in the form. If 2FA is enabled, provide the
+current code as well to download your option orders as JSON. The page is styled
+with a simple green theme that resembles Robinhood's login screen.

--- a/fetch_options_history.py
+++ b/fetch_options_history.py
@@ -1,0 +1,27 @@
+import json
+import getpass
+import robin_stocks.robinhood as r
+
+
+def login():
+    """Prompt for credentials and perform Robinhood login."""
+    username = input("Robinhood username: ")
+    password = getpass.getpass("Robinhood password: ")
+    mfa = input("2FA code (if enabled, otherwise leave blank): ")
+    r.login(username=username, password=password, mfa_code=mfa or None)
+
+
+def fetch_all_option_orders() -> list:
+    return r.orders.get_all_option_orders()
+
+
+def main():
+    login()
+    orders = fetch_all_option_orders()
+    with open("option_orders.json", "w") as f:
+        json.dump(orders, f, indent=2)
+    print(f"Saved {len(orders)} orders to option_orders.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/webapp.py
+++ b/webapp.py
@@ -1,0 +1,102 @@
+import json
+from flask import Flask, request, jsonify, render_template_string
+import robin_stocks.robinhood as r
+
+app = Flask(__name__)
+
+FORM_HTML = """
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Robinhood Options Exporter</title>
+  <style>
+    body {
+      margin: 0;
+      font-family: Helvetica, Arial, sans-serif;
+      background-color: #f5f5f5;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+    }
+    .card {
+      background: #fff;
+      padding: 40px;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      width: 320px;
+    }
+    h1 {
+      font-size: 24px;
+      font-weight: 600;
+      margin-top: 0;
+      margin-bottom: 20px;
+      color: #222;
+    }
+    label {
+      font-size: 14px;
+      color: #555;
+    }
+    input {
+      width: 100%;
+      padding: 8px;
+      margin-top: 4px;
+      margin-bottom: 12px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      box-sizing: border-box;
+    }
+    button {
+      width: 100%;
+      background: #00c806;
+      color: white;
+      border: none;
+      padding: 10px 0;
+      border-radius: 4px;
+      font-size: 16px;
+      cursor: pointer;
+    }
+    button:hover {
+      background: #009b05;
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Sign in</h1>
+    <form method="post" action="/fetch">
+      <label>Username</label>
+      <input type="text" name="username" required>
+      <label>Password</label>
+      <input type="password" name="password" required>
+      <label>2FA code (if enabled)</label>
+      <input type="text" name="mfa" placeholder="123456">
+      <button type="submit">Fetch Orders</button>
+    </form>
+  </div>
+</body>
+</html>
+"""
+
+@app.route("/", methods=["GET"])
+def index():
+    return render_template_string(FORM_HTML)
+
+@app.route("/fetch", methods=["POST"])
+def fetch():
+    username = request.form.get("username")
+    password = request.form.get("password")
+    mfa = request.form.get("mfa")
+    if not username or not password:
+        return "Missing credentials", 400
+    r.login(username=username, password=password, mfa_code=mfa or None)
+    orders = r.orders.get_all_option_orders()
+    r.logout()
+    return app.response_class(
+        response=json.dumps(orders, indent=2),
+        mimetype="application/json"
+    )
+
+if __name__ == "__main__":
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- add script to download option orders from Robinhood
- document setup and usage in README
- style the webapp to resemble Robinhood's login page

## Testing
- `python3 -m py_compile fetch_options_history.py webapp.py`


------
https://chatgpt.com/codex/tasks/task_e_6840fcc3fe5c832993dd59edafca2389